### PR TITLE
Add GitHub PR parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# GitHub Code Review Parser
+
+This repository provides a simple parser for GitHub pull request review comments.
+It fetches each review comment, its diff hunk, and the full diff between the PR
+base commit and the commit to which the comment was attached.
+
+## Requirements
+
+- Python 3.8+
+- `requests` library
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Create a file `requirements.txt` containing `requests`.
+
+## Usage
+
+Set the `GITHUB_API_KEY` environment variable with a GitHub personal access
+token to increase rate limits (default unauthenticated limit is 60 requests per
+hour).
+
+Run the parser for a repository and pull request number:
+
+```bash
+./parse_repo.py <owner> <repo> <pull_number>
+```
+
+The script outputs the collected review comments in JSON format.

--- a/github_parser/api.py
+++ b/github_parser/api.py
@@ -1,0 +1,55 @@
+import os
+import time
+from typing import Dict, List, Optional
+
+import requests
+
+class GitHubAPI:
+    def __init__(self, token: Optional[str] = None, base_url: str = "https://api.github.com"):
+        self.token = token or os.getenv("GITHUB_API_KEY")
+        self.base_url = base_url.rstrip('/')
+        self.session = requests.Session()
+        if self.token:
+            self.session.headers.update({"Authorization": f"Bearer {self.token}"})
+        self.session.headers.update({"Accept": "application/vnd.github+json"})
+
+    def _request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
+        url = f"{self.base_url}{endpoint}"
+        while True:
+            resp = self.session.request(method, url, **kwargs)
+            remaining = int(resp.headers.get("X-RateLimit-Remaining", 1))
+            reset = int(resp.headers.get("X-RateLimit-Reset", 0))
+            if resp.status_code == 403 and remaining == 0:
+                sleep_for = max(reset - int(time.time()), 1)
+                time.sleep(sleep_for)
+                continue
+            resp.raise_for_status()
+            return resp
+
+    def get_pull(self, owner: str, repo: str, pull_number: int) -> Dict:
+        resp = self._request("GET", f"/repos/{owner}/{repo}/pulls/{pull_number}")
+        return resp.json()
+
+    def list_review_comments(self, owner: str, repo: str, pull_number: int, per_page: int = 100) -> List[Dict]:
+        comments = []
+        page = 1
+        while True:
+            resp = self._request(
+                "GET",
+                f"/repos/{owner}/{repo}/pulls/{pull_number}/comments",
+                params={"per_page": per_page, "page": page},
+            )
+            chunk = resp.json()
+            if not chunk:
+                break
+            comments.extend(chunk)
+            page += 1
+        return comments
+
+    def get_compare_diff(self, owner: str, repo: str, base: str, head: str) -> str:
+        resp = self._request(
+            "GET",
+            f"/repos/{owner}/{repo}/compare/{base}...{head}",
+            headers={"Accept": "application/vnd.github.v3.diff"},
+        )
+        return resp.text

--- a/github_parser/parser.py
+++ b/github_parser/parser.py
@@ -1,0 +1,47 @@
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, List
+
+from .api import GitHubAPI
+
+@dataclass
+class ReviewComment:
+    id: int
+    commit_id: str
+    path: str
+    diff_hunk: str
+    body: str
+    full_diff: str
+
+class PullRequestParser:
+    def __init__(self, api: GitHubAPI):
+        self.api = api
+
+    def parse_review_comments(self, owner: str, repo: str, pull_number: int) -> List[ReviewComment]:
+        pr_info = self.api.get_pull(owner, repo, pull_number)
+        base_sha = pr_info["base"]["sha"]
+        comments = self.api.list_review_comments(owner, repo, pull_number)
+
+        diff_cache: Dict[str, str] = {}
+        results: List[ReviewComment] = []
+
+        for c in comments:
+            commit_sha = c["commit_id"]
+            if commit_sha not in diff_cache:
+                diff_cache[commit_sha] = self.api.get_compare_diff(owner, repo, base_sha, commit_sha)
+            results.append(
+                ReviewComment(
+                    id=c["id"],
+                    commit_id=commit_sha,
+                    path=c["path"],
+                    diff_hunk=c.get("diff_hunk", ""),
+                    body=c.get("body", ""),
+                    full_diff=diff_cache[commit_sha],
+                )
+            )
+        return results
+
+    @staticmethod
+    def to_json(comments: List[ReviewComment]) -> str:
+        return json.dumps([c.__dict__ for c in comments], indent=2)

--- a/parse_repo.py
+++ b/parse_repo.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import argparse
+
+from github_parser.api import GitHubAPI
+from github_parser.parser import PullRequestParser
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Parse GitHub PR review comments")
+    parser.add_argument("owner", help="Repository owner")
+    parser.add_argument("repo", help="Repository name")
+    parser.add_argument("pull", type=int, help="Pull request number")
+    args = parser.parse_args()
+
+    api = GitHubAPI()
+    pr_parser = PullRequestParser(api)
+    comments = pr_parser.parse_review_comments(args.owner, args.repo, args.pull)
+    print(PullRequestParser.to_json(comments))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- add basic GitHub API wrapper with rate limit handling
- add parser to collect PR review comments and associated diffs
- provide CLI entry point `parse_repo.py`
- document usage and requirements

## Testing
- `pip install -r requirements.txt -q`
- `python -m py_compile github_parser/api.py github_parser/parser.py parse_repo.py`


------
https://chatgpt.com/codex/tasks/task_e_6865839be9b483339d769eb0808de2e4